### PR TITLE
Minor changes, not high priority, can wait til after rc1

### DIFF
--- a/Input/MX/gfxsave.cfg
+++ b/Input/MX/gfxsave.cfg
@@ -3,5 +3,6 @@ Language|lang|lang
 Timezone|timezone|tz
 Options|options|checkmd5|checkfs|toram|nousb2|acpi|from|hwclock|private
 Persistence|persist|frugal|persist
+Failsafe|safeboot|load|nomodeset|failsafe|xorg
 Console|console|vga
 

--- a/Input/MX/safeboot.men
+++ b/Input/MX/safeboot.men
@@ -1,0 +1,5 @@
+default     `
+Safe Video  `nomodeset xorg=safe
+Failsafe    `nomodeset failsafe
+nomodeset   `nomodeset
+load=all    `load=all

--- a/src/menu_safeboot.inc
+++ b/src/menu_safeboot.inc
@@ -38,6 +38,7 @@
     [ "default"     ""                         ]
     [ "Safe Video"  "nomodeset xorg=safe"      ]
     [ "Failsafe"    "nomodeset failsafe"       ]
+    [ "nomodeset"   "nomodeset"                ]
     [ "load=all"    "load=all"                 ]
 
 ] def


### PR DESCRIPTION
Add a missing safeboot.men file to Input/MX/
Add a "nomodeset" entry to that file and to menu_safeboot.src
Add a safeboot entry to gfxsave.cfg

I don't remember if I left safeboot out of gfxsave.cfg for a reason or if I just forgot.  I think I forgot.  ISTM that a user should be able to save an entry in that menu if they want to.  Maybe they need xorg=safe or nomodeset to boot to X.
